### PR TITLE
检查标签集的规范

### DIFF
--- a/hog_svm.py
+++ b/hog_svm.py
@@ -82,7 +82,10 @@ def get_name_label(file_path):
             #一般是name label  三部分，所以至少长度为3  所以可以通过这个忽略空白行
             if len(line)>=3: 
                 name_list.append(line.split(' ')[0])
-                label_list.append(line.split(' ')[1])
+                label_list.append(line.split(' ')[1].replace('\n','').replace('\r',''))
+                if not str(label_list[-1]).isdigit():
+                    print("label必须为数字，得到的是：",label_list[-1],"程序终止，请检查文件")
+                    exit(1)
     return name_list, label_list
 
 


### PR DESCRIPTION
由于标签集用户可能输入的不是数字，所以为了程序健壮性考虑，应该判断是否为数字